### PR TITLE
typo .eslitrc.js is ignored by npm

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -5,7 +5,7 @@ public/**/*.md
 public/**/*.html
 public/**/*.svg
 src/
-.eslingrc.js
+.eslintrc.js
 .gitignore
 .npmignore
 doc_server.ts


### PR DESCRIPTION
``` diff
- .eslingrc.js
+ .eslintrc.js
```
