### PR TITLE
query selector for adjusting links is fixed

### DIFF
--- a/src/client/modules/markdownAdjuster.ts
+++ b/src/client/modules/markdownAdjuster.ts
@@ -87,7 +87,7 @@ function replaceUrl(originalPath: string, currentUrl: string): string {
 }
 
 function adjustLinks(currentPage: { url: string }): void {
-  globalThis.document.querySelectorAll("article a").forEach((anchorTag) => {
+  globalThis.document.querySelectorAll("#article a").forEach((anchorTag) => {
     const hyperReference = anchorTag.getAttribute("href") as string;
     const replacedUrl = replaceUrl(hyperReference, currentPage.url);
     if (hyperReference === replacedUrl) {


### PR DESCRIPTION
``` diff
- querySelectorAll("article a")
+ querySelectorAll("#article a")
```
